### PR TITLE
Async cascade: better network requests planning

### DIFF
--- a/phoxy.js
+++ b/phoxy.js
@@ -216,11 +216,6 @@ phoxy._RenderSubsystem =
   ,
   RenderStrategy : "Will be replaced by selected strategy after compilation."
   ,
-  __REFACTOR_RenderPrototype : function (target, ejs, data, rendered_callback, difference)
-    {
-      phoxy.RenderStrategy.apply(this, arguments);
-    }
-  ,
   RenderInto : function (target, ejs, data, rendered_callback)
     { 
       var args = Array.prototype.slice.call(arguments);
@@ -228,7 +223,7 @@ phoxy._RenderSubsystem =
       {
         $(target).html(html);
       });
-      phoxy.__REFACTOR_RenderPrototype.apply(this, args);
+      phoxy.RenderStrategy.apply(this, args);
     }
   ,
   RenderReplace : function (target, ejs, data, rendered_callback)
@@ -238,7 +233,7 @@ phoxy._RenderSubsystem =
       {
         $(target).replaceWith(html);
       });
-      phoxy.__REFACTOR_RenderPrototype.apply(this, args);
+      phoxy.RenderStrategy.apply(this, args);
     }  
   ,
   Render : function (design, data, callback, is_phoxy_internal_call)

--- a/phoxy.js
+++ b/phoxy.js
@@ -877,9 +877,15 @@ phoxy._EarlyStage =
       }
 
       if (1 || phoxy.prestart.sync_cascade)
+      {
+        phoxy.state.sync_cascade = true;
         phoxy.RenderStrategy = phoxy.SyncRender_Strategy;
+      }
       else
+      {
+        phoxy.state.sync_cascade = false;
         phoxy.RenderStrategy = phoxy.AsyncRender_Strategy;
+      }
     }
 };
 
@@ -987,7 +993,9 @@ In that case use phoxy.Defer methods directly. They context-dependence free.");
       that.CheckIsCompleted.call(that.across);
     }
 
-    return OriginDefer.call(this, CBHook, time);
+    if (phoxy.state.sync_cascade)
+      return OriginDefer.call(this, CBHook, time);
+    phoxy.Log(0, "Coming soon");
   }
 
   EJS.Canvas.across.prototype.DeferCascade = function(callback)


### PR DESCRIPTION
New `DeferRender` causing immediately browser resource requests, resolute cascade dependencies in run-time(not after).
Its vastly faster for high-speed OR big-latency networks. You should prefer it for release.

Disadvantage: since cascade resolves immediately, its hard to debug cascade/complex_design issues.
Use `phoxy.sync_cascade = true` for early stages tuning.